### PR TITLE
Switching around the general deny/permit order. 

### DIFF
--- a/Sccp_manager.class.php
+++ b/Sccp_manager.class.php
@@ -2063,7 +2063,9 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
                     case "sccp_compatible":
                         break;
                     default:
-                        $this->sccp_conf_init['general'][$key] = $value['data'];
+                        if (!empty($value['data'])) {
+                            $this->sccp_conf_init['general'][$key] = $value['data'];
+                        }
                 }
             }
         }

--- a/Sccp_manager.class.php
+++ b/Sccp_manager.class.php
@@ -2036,14 +2036,21 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
         // Make sccp.conf data
         // [general]
         foreach ($this->sccpvalues as $key => $value) {
-            if ($value['seq'] == 0) {
+            if ($value['seq'] <= 3) {
                 switch ($key) {
-                    case "allow":
-                    case "disallow":
                     case "deny":
-                    case "localnet":
-                    case "permit":
+                    case "disallow":
+                    case "allow":
                         $this->sccp_conf_init['general'][$key] = explode(';', $value['data']);
+                        break;
+                    case "permit":
+                    case "localnet":
+                        $content = explode(';', $value['data']);
+                        if (in_array('internal', $content)) {
+                            $this->sccp_conf_init['general'][$key] = "internal";
+                        } else {
+                            $this->sccp_conf_init['general'][$key] = $content;
+                        }
                         break;
                     case "devlang":
                         $lang_data = $this->extconfigs->getextConfig('sccp_lang', $value['data']);

--- a/conf/sccpgeneral.xml
+++ b/conf/sccpgeneral.xml
@@ -102,23 +102,23 @@ and open the template in the editor. Base Version before all crash :-)
     </page_group>
     <page_group name="sccp_net"><label>SCCP Networks</label>
       <item type="IED" id="1" seq="0">
-        <label>Allow Networks / Mask</label>
-        <name>permit</name>
-        <default>0.0.0.0/0.0.0.0</default>
-        <input value="NONE" field="net" nameseparator="/"><options placeholder="0.0.0.0" pattern="^([0-9]{1,3}\.){3}[0-9]{1,3}$"/></input>
-        <input value="NONE" field="mask"><options placeholder="255.255.255.0" pattern="^([0-9]{1,3}\.){3}[0-9]{1,3}$"/> </input>
-        <addbutton>Add Allow network</addbutton>
-        <help>Allow network settings. Blank fields will be ignored, use Network 0.0.0.0.</help>
-      </item>
-
-      <item type="IED" id="2" seq="0">
         <label>Deny Networks / Mask</label>
         <name>deny</name>
         <default>0.0.0.0/0.0.0.0</default>
         <input value="NONE" field="net" nameseparator="/"><options placeholder="0.0.0.0" pattern="^([0-9]{1,3}\.){3}[0-9]{1,3}$"/><class></class></input>
         <input value="NONE" field="mask"><options placeholder="255.255.255.0" pattern="^([0-9]{1,3}\.){3}[0-9]{1,3}$"/><class></class></input>
-        <addbutton>Add Deny network</addbutton>
+        <addbutton>Deny a network</addbutton>
         <help>All RFC 1918 addresses are local networks. Should always be at least '0.0.0.0/0.0.0.0'.</help>
+      </item>
+
+      <item type="IED" id="2" seq="0">
+        <label>Permit Networks / Mask</label>
+        <name>permit</name>
+        <default>0.0.0.0/0.0.0.0</default>
+        <input value="NONE" field="net" nameseparator="/"><options placeholder="0.0.0.0" pattern="^([0-9]{1,3}\.){3}[0-9]{1,3}$"/></input>
+        <input value="NONE" field="mask"><options placeholder="255.255.255.0" pattern="^([0-9]{1,3}\.){3}[0-9]{1,3}$"/> </input>
+        <addbutton>Permit a network</addbutton>
+        <help>Permit devices from this network to connect to the server. Blank fields will be ignored, use Network 0.0.0.0.</help>
       </item>
 
       <item type="IED" id="3" seq="0">
@@ -127,7 +127,7 @@ and open the template in the editor. Base Version before all crash :-)
         <default>0.0.0.0/0.0.0.0</default>
         <input value="NONE" field="net" nameseparator="/"><options placeholder="0.0.0.0" pattern="^([0-9]{1,3}\.){3}[0-9]{1,3}$" /><class></class></input>
         <input value="NONE" field="mask"><options placeholder="255.255.255.0" pattern="^([0-9]{1,3}\.){3}[0-9]{1,3}$"/> <class></class></input>
-        <addbutton>Add local networks</addbutton>
+        <addbutton>Add a local network</addbutton>
         <help>Local network settings. Blank fields will be ignored used Network 0.0.0.0.</help>
       </item>
 

--- a/conf/sccpgeneral.xml.v433
+++ b/conf/sccpgeneral.xml.v433
@@ -169,7 +169,7 @@ and open the template in the editor. Base Version before all crash :-)
     <page_group name="sccp_net">
         <label>SCCP Networks</label>
 
-        <item type="IED" id="1" seq="0">
+        <item type="IED" id="1" seq="1">
             <label>Deny Networks / Mask</label>
             <name>deny</name>
             <default>0.0.0.0/0.0.0.0</default>
@@ -186,7 +186,7 @@ and open the template in the editor. Base Version before all crash :-)
             <help>All RFC 1918 addresses are local networks. Should always be at least '0.0.0.0/0.0.0.0'.</help>
         </item>
 
-        <item type="IED" id="2" seq="0">
+        <item type="IED" id="2" seq="2">
             <label>Permit Networks / Mask</label>
             <name>permit</name>
             <cbutton field="internal" value="internal">Internal</cbutton>
@@ -204,7 +204,7 @@ and open the template in the editor. Base Version before all crash :-)
             You can use the 'internal' which will be interpreted as the 3 IANA private network classes (192.168, 172 and 10). </help>
         </item>
 
-        <item type="IED" id="3" seq="0">
+        <item type="IED" id="3" seq="3">
             <label>Local Networks / Mask</label>
             <name>localnet</name>
             <cbutton field="internal" value="internal">Internal</cbutton>

--- a/conf/sccpgeneral.xml.v433
+++ b/conf/sccpgeneral.xml.v433
@@ -168,8 +168,26 @@ and open the template in the editor. Base Version before all crash :-)
     </page_group>
     <page_group name="sccp_net">
         <label>SCCP Networks</label>
+
         <item type="IED" id="1" seq="0">
-            <label>Allow Networks / Mask</label>
+            <label>Deny Networks / Mask</label>
+            <name>deny</name>
+            <default>0.0.0.0/0.0.0.0</default>
+            <input value="NONE" field="net" nameseparator="/">
+                <options placeholder="0.0.0.0" pattern="^([0-9]{1,3}\.){3}[0-9]{1,3}$"/>
+                <class></class>
+            </input>
+            <input value="NONE" field="mask">
+                <options placeholder="255.255.255.0" pattern="^([0-9]{1,3}\.){3}[0-9]{1,3}$"/>
+                <class></class>
+            </input>
+            <add_pluss>+</add_pluss>
+            <addbutton-disabled>Deny a network/range</addbutton-disabled>
+            <help>All RFC 1918 addresses are local networks. Should always be at least '0.0.0.0/0.0.0.0'.</help>
+        </item>
+
+        <item type="IED" id="2" seq="0">
+            <label>Permit Networks / Mask</label>
             <name>permit</name>
             <cbutton field="internal" value="internal">Internal</cbutton>
             <default>0.0.0.0/0.0.0.0</default>
@@ -180,10 +198,11 @@ and open the template in the editor. Base Version before all crash :-)
                 <options placeholder="255.255.255.0" pattern="^([0-9]{1,3}\.){3}[0-9]{1,3}$"/> 
             </input>
             <add_pluss>+</add_pluss>
-            <addbutton-disabled>Add Allow Range</addbutton-disabled>
-            <help>Allow network settings. Blank fields will be ignored used Network 0.0.0.0/0.0.0.0 to resolve any existing connections. You can use the 'internal' connections only from the networks connected to the server. </help>
+            <addbutton-disabled>Permit a network/range</addbutton-disabled>
+            <help>Permit devices from this network(s) to connect to the server.
+            Blank fields will be ignored. Entering '0.0.0.0/0.0.0.0' will mean any/all.
+            You can use the 'internal' which will be interpreted as the 3 IANA private network classes (192.168, 172 and 10). </help>
         </item>
-
 
         <item type="IED" id="3" seq="0">
             <label>Local Networks / Mask</label>
@@ -200,23 +219,9 @@ and open the template in the editor. Base Version before all crash :-)
             </input>
             <add_pluss>+</add_pluss>
             <addbutton-disabled>Add Internal Range</addbutton-disabled>
-            <help>Local network settings. Blank fields will be ignored used Network 0.0.0.0.</help>
-        </item>
-        <item type="IED" id="2" seq="0">
-            <label>Deny Networks / Mask</label>
-            <name>deny</name>
-            <default>0.0.0.0/0.0.0.0</default>
-            <input value="NONE" field="net" nameseparator="/">
-                <options placeholder="0.0.0.0" pattern="^([0-9]{1,3}\.){3}[0-9]{1,3}$"/>
-                <class></class>
-            </input>
-            <input value="NONE" field="mask">
-                <options placeholder="255.255.255.0" pattern="^([0-9]{1,3}\.){3}[0-9]{1,3}$"/>
-                <class></class>
-            </input>
-            <add_pluss>+</add_pluss>
-            <addbutton-disabled>Add Deny network</addbutton-disabled>
-            <help>All RFC 1918 addresses are local networks. Should always be at least '0.0.0.0/0.0.0.0'.</help>
+            <help>Local network settings.
+            Blank fields will be ignored. Entering '0.0.0.0/0.0.0.0' will mean any/all.
+            You can use the 'internal' which will be interpreted as the 3 IANA private network classes (192.168, 172 and 10). </help>
         </item>
 
         <item type="IED" id="1" seq="98">
@@ -236,7 +241,6 @@ and open the template in the editor. Base Version before all crash :-)
             <addbutton-disabled>Add Address</addbutton-disabled>
             <help>This function is useful when the server has many interfaces, but devices must connect only to some interfaces.</help>
         </item>
-
 
     </page_group>
     <page_group name="sccp_lang">


### PR DESCRIPTION
It's important to have deny before permit (just like all other channel drivers and the config files)

TODO: The resulting sccp.conf should also reflect this. Not sure if that is the case ?

Signed-off-by: Diederik de Groot <dkgroot@talon.nl>