### PR TITLE
Fix outboundcid: parse outboundcid content into cid_num and cid_name sccpline fields

### DIFF
--- a/conf/Sccp.class.php.v433
+++ b/conf/Sccp.class.php.v433
@@ -19,7 +19,7 @@ class Sccp extends \FreePBX\modules\Core\Driver {
                                  'namedcallgroup'=>'namedcallgroup', 'namedpickupgroup' => 'namedpickupgroup',            
                                  "transfer" => 'transfer', "echocancel" => 'echocancel',
                                  "language" => 'language', "description" => 'callerid',
-                                 "cid_num" => 'cid_num', "cid_name" => 'label', "mailbox" => 'mailbox',
+                                 "cid_num" => 'cid_num', "cid_name" => 'cid_name', "mailbox" => 'mailbox',
                                  "musicclass" => 'musicclass',"allow" => 'allow',"disallow" => 'disallow',
                                  "videomode" => 'videomode',
                                  "dnd" => 'dnd', "silencesuppression" => 'silencesuppression',
@@ -63,8 +63,10 @@ class Sccp extends \FreePBX\modules\Core\Driver {
 //                print_r($_REQUEST);
 //                echo '<br><br>';
 //                die(print_r($settings));
-                $settings['cid_num']['value']='';
+                $settings['cid_num']['value'] = '';
+                $settings['cid_name']['value'] = $label;
                 $settings['mailbox']['value']= '';
+
                 if (isset($_REQUEST)){
                     foreach($add_fld as $key => $val) {
                         if (!empty($_REQUEST[$key])){
@@ -80,10 +82,19 @@ class Sccp extends \FreePBX\modules\Core\Driver {
                 }
                 $settings['allow']['value'] = implode(",", $allow_codec);
 
+		// parse outboundcid content into cid_num and cid_name sccpline fields
                 if (empty($settings['cid_num']['value'])) {
-                    $settings['cid_num']['value']= $id;
+                    $settings['cid_num']['value'] = $id;
+                } else {
+                    $outboundcid = $settings['cid_num']['value'];
+                    if (preg_match('/"(.*)"\s?<(.*)>/', $outboundcid, $matches)) {
+                        $settings['cid_num']['value'] = $matches[2];
+                        $settings['cid_name']['value'] = $matches[1];
+                    } else if (is_integer($outboundcid)) {
+                        $settings['cid_num']['value'] = $outboundcid;
+                    }
                 }
-                
+
                 if (!empty($_REQUEST['vm']) && ($_REQUEST['vm'] =='enabled')){ // mailbox 
                     if (empty($settings['mailbox']['value'])) {
                         $settings['mailbox']['value']= $id;


### PR DESCRIPTION
If outboundcid contains '"name" <num>' the content needs to be split to cid_name and cid_num.
If not the content should be a number and should be copied to cid_num only, in that case we fill cid_name with the value of $label

Fixes: #72