### PR TITLE
Fixed recognition of chan-sccp release version 4.3.3

### DIFF
--- a/Sccp_manager.inc/aminterface/oldinterface.class.php
+++ b/Sccp_manager.inc/aminterface/oldinterface.class.php
@@ -300,7 +300,11 @@ class oldinterface
                 } elseif ($version_parts[1] == "2") {
                     $result["vCode"] = 420;
                 } elseif ($version_parts[1] >= "3") {
-                    $result["vCode"] = 430;
+                    if ($version_parts[2] == "3"){
+                        $result["vCode"] = 433;
+                    } else {
+                        $result["vCode"] = 430;
+                    }          
                 }
             }
 

--- a/Sccp_manager.inc/srvinterface.class.php
+++ b/Sccp_manager.inc/srvinterface.class.php
@@ -271,7 +271,11 @@ class srvinterface {
                             $result["vCode"] = 420;
                             break;
                         case 3. . .5:
-                            $result["vCode"] = 430;
+                            if($version_parts[2] == "3"){
+                                $result["vCode"] = 433;
+                            } else {
+                                $result["vCode"] = 430;
+                            }
                             break;
                         default:
                             $result["vCode"] = 400;


### PR DESCRIPTION
Installing sccp-manager with the latest release of chan-sccp v4.3.3 was not correctly recognized the vCode. 
It was considered 430 instead of 433 so the tables were created badly in particular the table related to the configuration of the buttons. 
This problem made the module unusable.