### PR TITLE
Fix soft keys

### DIFF
--- a/Sccp_manager.inc/aminterface/Message.class.php
+++ b/Sccp_manager.inc/aminterface/Message.class.php
@@ -12,7 +12,7 @@ namespace FreePBX\modules\Sccp_manager\aminterface;
 
 class AMIException extends \Exception
 {
-    
+
 }
 
 abstract class Message

--- a/Sccp_manager.inc/aminterface/Response.class.php
+++ b/Sccp_manager.inc/aminterface/Response.class.php
@@ -72,7 +72,6 @@ abstract class Response extends IncomingMessage
         $this->setKey('ActionId', $actionId);
     }
 
-    
     public function getVariable($_rawContent, $_fields = '')
     {
         $lines = explode(Message::EOL, $_rawContent);
@@ -119,7 +118,6 @@ class Login_Response extends Response
 class Command_Response extends Response
 {
     private $_temptable;
-    
     public function __construct($rawContent)
     {
 //        print_r('<br>---- r --<br>');
@@ -127,7 +125,6 @@ class Command_Response extends Response
 //        print_r('<br>---- re --<br>');
         $this->_temptable = array();
         parent::__construct($rawContent);
-
         $lines = explode(Message::EOL, $rawContent);
         foreach ($lines as $line) {
             $content = explode(':', $line);
@@ -148,7 +145,7 @@ class Command_Response extends Response
         if (!empty($this->_temptable)) {
             $this->setKey('output', 'array');
         }
-            
+
         $this->_completed = $this->isSuccess();
 //        return $this->isSuccess();
     }
@@ -165,7 +162,7 @@ class Command_Response extends Response
 
 class SCCPGeneric_Response extends Response
 {
-    
+
     protected $_tables;
     private $_temptable;
 
@@ -208,7 +205,7 @@ class SCCPGeneric_Response extends Response
             $this->_completed = true;
         }
     }
-    
+
     protected function ConvertTableData($_tablename, $_fkey, $_fields)
     {
         $_rawtable = $this->Table2Array($_tablename);
@@ -278,8 +275,8 @@ class SCCPGeneric_Response extends Response
         }
         return $result;
     }
-    
-    
+
+
     public function hasTable()
     {
         if (is_array($this->_tables)) {
@@ -291,7 +288,7 @@ class SCCPGeneric_Response extends Response
     {
         return (is_array($this->_tables)) ? array_keys($this->_tables) : null;
     }
-    
+
     public function Table2Array($tablename = '')
     {
         $result =array();
@@ -324,7 +321,7 @@ class SCCPGeneric_Response extends Response
             return false;
         }
     }
-    
+
     public function getTable($tablename)
     {
         if ($this->hasTable() && array_key_exists($tablename, $this->_tables)) {
@@ -349,7 +346,7 @@ class SCCPGeneric_Response extends Response
 //        $this->getVariable($rawContent, $_fields);
         $this->_completed = !$this->isList();
     }
-    
+
     public function getResult()
     {
         if ($this->getKey('JSON') != null) {

--- a/Sccp_manager.inc/aminterface/aminterface.class.php
+++ b/Sccp_manager.inc/aminterface/aminterface.class.php
@@ -55,8 +55,8 @@ class aminterface
         $this->_connect_state = false;
         $this->_error = array();
         $this->_config = array('host' => 'localhost', 'user' => '', 'pass' => '', 'port' => '5038', 'tsoket' => 'tcp://', 'timeout' => 30, 'enabled' => false);
-        
-        
+
+
         $this->_eventListeners = array();
 //  $this->_eventFactory = new EventFactoryImpl(\Logger::getLogger('EventFactory'));
 //  $this->_responseFactory = new ResponseFactoryImpl(\Logger::getLogger('ResponseFactory'));
@@ -259,7 +259,7 @@ class aminterface
                     $response = $this->findResponse($event);
 //                    print_r($response);
 //                    print_r('<br>--- E2 Response Type 2 ----------<br>');
-                    
+
                     if ($response === false || $response->isComplete()) {
                         $this->dispatch($event);  // не работает
                     } else {
@@ -409,7 +409,7 @@ class aminterface
             $listener = $data[0];
             $predicate = $data[1];
             print_r($data);
-            
+
             if (is_callable($predicate) && !call_user_func($predicate, $message)) {
                 continue;
             }

--- a/Sccp_manager.inc/aminterface/aminterface.class.php
+++ b/Sccp_manager.inc/aminterface/aminterface.class.php
@@ -54,15 +54,13 @@ class aminterface
         $this->_socket = false;
         $this->_connect_state = false;
         $this->_error = array();
-        $this->_config = array('host' => 'localhost', 'user' => '', 'pass' => '', 'port' => '5038', 'tsoket' => 'tcp://', 'timeout' => 30, 'enabled' => false);
-
-
+        $this->_config = array('host' => 'localhost', 'user' => '', 'pass' => '', 'port' => '5038', 'tsoket' => 'tcp://', 'timeout' => 30, 'enabled' => true);
         $this->_eventListeners = array();
 //  $this->_eventFactory = new EventFactoryImpl(\Logger::getLogger('EventFactory'));
 //  $this->_responseFactory = new ResponseFactoryImpl(\Logger::getLogger('ResponseFactory'));
         $this->_incomingQueue = array();
         $this->_lastActionId = false;
-        
+
         $fld_conf = array('user' => 'AMPMGRUSER', 'pass' => 'AMPMGRPASS');
         if (isset($amp_conf['AMPMGRUSER'])) {
             foreach ($fld_conf as $key => $value) {
@@ -259,7 +257,6 @@ class aminterface
                     $response = $this->findResponse($event);
 //                    print_r($response);
 //                    print_r('<br>--- E2 Response Type 2 ----------<br>');
-
                     if ($response === false || $response->isComplete()) {
                         $this->dispatch($event);  // не работает
                     } else {
@@ -267,8 +264,8 @@ class aminterface
                     }
                 }
             } else {
-                // broken ami.. sending a response with events without
-                // Event and ActionId
+                // broken ami most probably through changes in chan_sccp_b.
+                //sending a response with events without Event and ActionId
                 $this->_msgToDebug(1, 'resp broken ami');
                 $bMsg = 'Event: ResponseEvent' . "\r\n";
                 $bMsg .= 'ActionId: ' . $this->_lastActionId . "\r\n" . $aMsg;
@@ -543,17 +540,29 @@ class aminterface
 
     function getRealTimeStatus()
     {
+        // Initialise array with default values to eliminate testing later
         $result = array();
+        $cmd_res = array();
+        $cmd_res = ['sccp' => ['message' => 'default value', 'realm' => '', 'status' => 'ERROR']];
         if ($this->_connect_state) {
             $_action = new \FreePBX\modules\Sccp_manager\aminterface\CommandAction('realtime mysql status');
-            $_response = $this->send($_action);
-            $res = $_response->getResult();
-            if (!empty($res['output'])) {
-                $result = $res['output'];
-            } else {
-                $result = $_response->getMessage();
+            $result = $this->send($_action)->getResult();
+         }
+         if (is_array($result['Output'])) {
+             foreach ($result['Output'] as $aline) {
+                 if (strlen($aline) > 3) {
+                     $temp_strings = explode(' ', $aline);
+                     $cmd_res_key = $temp_strings[0];
+                     foreach ($temp_strings as $test_string) {
+                          if (strpos($test_string, '@')) {
+                            $this_realm = $test_string;
+                            break;
+                          }
+                     }
+                     $cmd_res[$cmd_res_key] = array('message' => $aline, 'realm' => $this_realm, 'status' => strpos($aline, 'connected') ? 'OK' : 'ERROR');
+                 }
             }
         }
-        return $result;
+        return $cmd_res;
     }
 }

--- a/Sccp_manager.inc/aminterface/oldinterface.class.php
+++ b/Sccp_manager.inc/aminterface/oldinterface.class.php
@@ -180,6 +180,8 @@ class oldinterface
     public function sccp_realtime_status()
     {
         $ast_res = array();
+        // Below added for compatibility with AMI result and modified server.info
+        $ast_res = ['sccp' => ['message' => 'default value', 'realm' => '', 'status' => 'ERROR']];
         $ast_out = $this->sccp_core_commands(array('cmd' => 'get_realtime_status'));
         $ast_out = preg_split("/[\n]/", $ast_out['data']);
         if (strpos($ast_out[0], 'Privilege') !== false) {

--- a/Sccp_manager.inc/extconfigs.class.php
+++ b/Sccp_manager.inc/extconfigs.class.php
@@ -45,11 +45,11 @@ class extconfigs
                 $tmp_dt = new \DateTime(null, new \DateTimeZone($index));
                 $tmp_ofset = $tmp_dt->getOffset();
                 return $tmp_ofset / 60;
-                
+
                 break;
             case 'sccp_timezone': // Sccp manafer: 1400 (+ Id) :2007 (+ Id)
                 $result = array();
-                
+
                 if (empty($index)) {
                     return array('offset' => '00', 'daylight' => '', 'cisco_code' => 'Greenwich');
                 }
@@ -57,7 +57,7 @@ class extconfigs
                     return  $this->get_cisco_time_zone($index);
                 } else {
                     $timezone_abbreviations = \DateTimeZone::listAbbreviations();
-                    
+
                     $tz_tmp = array();
                     foreach ($timezone_abbreviations as $subArray) {
                         $tf_idt = array_search($index, array_column($subArray, 'timezone_id'));
@@ -109,7 +109,7 @@ class extconfigs
 
     private function get_cisco_time_zone($tzc)
     {
-    
+
         if ((empty($tzc)) or (!array_key_exists($tzc, $this->cisco_timezone))) {
 //            return array('offset' => '00', 'daylight' => '', 'cisco_code' => 'Greenwich');
             return array();
@@ -464,14 +464,14 @@ class extconfigs
         $res['extconfig'] = 'OK';
 
         if (empty($res['sccpdevice'])) {
-            $res['extconfig'] = ' Options "Sccpdevice" not config ';
+            $res['extconfig'] = ' Option "Sccpdevice" is not configured ';
         }
         if (empty($res['sccpline'])) {
-            $res['extconfig'] = ' Options "Sccpline" not config ';
+            $res['extconfig'] = ' Option "Sccpline" is not configured ';
         }
 
         if (empty($res['extconfigfile'])) {
-            $res['extconfig'] = 'File extconfig.conf not exist';
+            $res['extconfig'] = 'File extconfig.conf does not exist';
         }
 
 
@@ -483,10 +483,10 @@ class extconfigs
         if (file_exists($dir . '/res_mysql.conf')) {
             $res_conf = $cnf_read->getConfig('res_mysql.conf');
             if (empty($res_conf[$realm])) {
-                $res['mysqlconfig'] = 'Not Config in file: res_mysql.conf';
+                $res['mysqlconfig'] = 'Config not found in file: res_mysql.conf';
             } else {
                 if ($res_conf[$realm]['dbsock'] != $def_bd_config['dbsock']) {
-                    $res['mysqlconfig'] = 'Mysql Soket Error in file: res_mysql.conf';
+                    $res['mysqlconfig'] = 'Mysql Socket Error in file: res_mysql.conf';
                 }
             }
             if (empty($res['mysqlconfig'])) {
@@ -500,7 +500,7 @@ class extconfigs
                 $res['mysqlconfig'] = 'Not Config in file: res_config_mysql.conf';
             } else {
                 if ($res_conf[$realm]['dbsock'] != $def_bd_config['dbsock']) {
-                    $res['mysqlconfig'] = 'Mysql Soket Error in file: res_config_mysql.conf';
+                    $res['mysqlconfig'] = 'Mysql Socket Error in file: res_config_mysql.conf';
                 }
             }
             if (empty($res['mysqlconfig'])) {

--- a/Sccp_manager.inc/extconfigs.class.php
+++ b/Sccp_manager.inc/extconfigs.class.php
@@ -419,10 +419,10 @@ class extconfigs
     {
         global $amp_conf;
         $res = array();
-        if (empty($realm)) {
+/*        if (empty($realm)) {
             $realm = 'sccp';
         }
-        $cnf_int = \FreePBX::Config();
+*/        $cnf_int = \FreePBX::Config();
         $cnf_wr = \FreePBX::WriteConfig();
         $cnf_read = \FreePBX::LoadConfig();
 

--- a/Sccp_manager.inc/srvinterface.class.php
+++ b/Sccp_manager.inc/srvinterface.class.php
@@ -236,11 +236,11 @@ class srvinterface {
 
     public function sccp_list_keysets() {
 
-/*        if ($this->ami_mode) {
+        if ($this->ami_mode) {
             return $this->aminterface->sccp_list_keysets();
         } else {
-*/            return $this->oldinterface->sccp_list_keysets();
-//        }
+            return $this->oldinterface->sccp_list_keysets();
+        }
 
     }
 

--- a/Sccp_manager.inc/srvinterface.class.php
+++ b/Sccp_manager.inc/srvinterface.class.php
@@ -193,8 +193,8 @@ class srvinterface {
         if (!$this->ami_mode) {
             return $this->oldinterface->sccp_realtime_status();
         } else {
-            $ast_out = $this->aminterface->getRealTimeStatus();
-            if (is_array($ast_out)) {
+            return $this->aminterface->getRealTimeStatus();
+/*            if (is_array($ast_out)) {
                 foreach ($ast_out as $aline) {
                     if (strlen($aline) > 3) {
                         $ast_key = strstr(trim($aline), ' ', true);
@@ -203,7 +203,7 @@ class srvinterface {
                 }
             }
             return $ast_res;
-        }
+*/        }
     }
 
     public function get_compatible_sccp() {
@@ -236,11 +236,12 @@ class srvinterface {
 
     public function sccp_list_keysets() {
 
-        if ($this->ami_mode) {
+/*        if ($this->ami_mode) {
             return $this->aminterface->sccp_list_keysets();
         } else {
-            return $this->oldinterface->sccp_list_keysets();
-        }
+*/            return $this->oldinterface->sccp_list_keysets();
+//        }
+
     }
 
     public function sccp_get_active_device() {

--- a/page.html.php
+++ b/page.html.php
@@ -1,0 +1,46 @@
+<div class="container-fluid">
+    <h1><?php echo $display_info?></h1>
+    <div class="row">
+        <div class="col-sm-12">
+            <div class="fpbx-container">
+                <div class="display no-border">
+                    <div class="nav-container">
+                        <div class="scroller scroller-left"><i class="glyphicon glyphicon-chevron-left"></i></div>
+                        <div class="scroller scroller-right"><i class="glyphicon glyphicon-chevron-right"></i></div>
+                        <div class="wrapper">
+                            <ul class="nav nav-tabs list" role="tablist">
+                                <?php foreach ($display_page as $key => $page) { ?>
+                                    <li data-name="<?php echo $key?>" class="change-tab <?php echo $key == 'general' ? 'active' : ''?>"><a href="#<?php echo $key?>" aria-controls="<?php echo $key?>" role="tab" data-toggle="tab"><?php echo $page['name']?></a></li>
+                                <?php } ?>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="tab-content display">
+                        <?php foreach ($display_page as $key => $page) { ?>
+                            <div id="<?php echo $key?>" class="tab-pane <?php echo $key == 'general' ? 'active' : ''?>">
+                                <?php echo $page['content']?>
+                            </div>
+                        <?php } ?>
+                                        </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<!-- Modal alerts-->
+<div class="modal" id="hwalert" tabindex="-1" role="dialog" aria-labelledby="lhwalert">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title" id="myModalLabel">Modal title</h4>
+      </div>
+      <div class="modal-body">
+        ...
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/page.sccp_adv.php
+++ b/page.sccp_adv.php
@@ -22,53 +22,7 @@ if (empty($spage->class_error)) {
     $display_page = $spage->infoServerShowPage();
     $display_info = _("SCCP Server Configuration");
 }
+
+include('page.html.php');
 ?>
-
-<div class="container-fluid">
-    <h1><?php echo $display_info?></h1>
-    <div class="row">
-        <div class="col-sm-12">
-            <div class="fpbx-container">
-                <div class="display no-border">
-                    <div class="nav-container">
-                        <div class="scroller scroller-left"><i class="glyphicon glyphicon-chevron-left"></i></div>
-                        <div class="scroller scroller-right"><i class="glyphicon glyphicon-chevron-right"></i></div>
-                        <div class="wrapper">
-                            <ul class="nav nav-tabs list" role="tablist">
-                                <?php foreach ($display_page as $key => $page) { ?>
-                                    <li data-name="<?php echo $key?>" class="change-tab <?php echo $key == 'general' ? 'active' : ''?>"><a href="#<?php echo $key?>" aria-controls="<?php echo $key?>" role="tab" data-toggle="tab"><?php echo $page['name']?></a></li>
-                                <?php } ?>
-                            </ul>
-                        </div>
-                    </div>
-                    <div class="tab-content display">
-                        <?php foreach ($display_page as $key => $page) { ?>
-                            <div id="<?php echo $key?>" class="tab-pane <?php echo $key == 'general' ? 'active' : ''?>">
-                                <?php echo $page['content']?>
-                            </div>
-                        <?php } ?>
-                                        </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
-<!-- Modal alerts-->
-<div class="modal" id="hwalert" tabindex="-1" role="dialog" aria-labelledby="lhwalert">
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title" id="myModalLabel">Modal title</h4>
-      </div>
-      <div class="modal-body">
-        ...
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-      </div>
-    </div>
-  </div>
-</div>
-
 <!-- End Modal alerts-->

--- a/page.sccp_phone.php
+++ b/page.sccp_phone.php
@@ -22,54 +22,7 @@ if (empty($spage->class_error)) {
     $display_page = $spage->infoServerShowPage();
     $display_info = _("SCCP Server Configuration");
 }
-
+include('page.html.php');
 ?>
-
-<div class="container-fluid">
-    <h1><?php echo $display_info?></h1>
-    <div class="row">
-        <div class="col-sm-12">
-            <div class="fpbx-container">
-                <div class="display no-border">
-                    <div class="nav-container">
-                        <div class="scroller scroller-left"><i class="glyphicon glyphicon-chevron-left"></i></div>
-                        <div class="scroller scroller-right"><i class="glyphicon glyphicon-chevron-right"></i></div>
-                        <div class="wrapper">
-                            <ul class="nav nav-tabs list" role="tablist">
-                                <?php foreach ($display_page as $key => $page) { ?>
-                                    <li data-name="<?php echo $key?>" class="change-tab <?php echo $key == 'general' ? 'active' : ''?>"><a href="#<?php echo $key?>" aria-controls="<?php echo $key?>" role="tab" data-toggle="tab"><?php echo $page['name']?></a></li>
-                                <?php } ?>
-                            </ul>
-                        </div>
-                    </div>
-                    <div class="tab-content display">
-                        <?php foreach ($display_page as $key => $page) { ?>
-                            <div id="<?php echo $key?>" class="tab-pane <?php echo $key == 'general' ? 'active' : ''?>">
-                                <?php echo $page['content']?>
-                            </div>
-                        <?php } ?>
-                                        </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
-<!-- Modal alerts-->
-<div class="modal" id="hwalert" tabindex="-1" role="dialog" aria-labelledby="lhwalert">
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title" id="myModalLabel">Modal title</h4>
-      </div>
-      <div class="modal-body">
-        ...
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-      </div>
-    </div>
-  </div>
-</div>
 
 <!-- End Modal alerts-->

--- a/page.sccpsettings.php
+++ b/page.sccpsettings.php
@@ -11,53 +11,11 @@ if (!defined('FREEPBX_IS_AUTH')) {
 
 //
 $spage = FreePBX::create()->Sccp_manager;
-?>
 
-<div class="container-fluid">
-    <h1><?php echo _("SCCP Server Settings")?></h1>
-    <div class="row">
-        <div class="col-sm-12">
-            <div class="fpbx-container">
-                <div class="display no-border">
-                    <div class="nav-container">
-                        <div class="scroller scroller-left"><i class="glyphicon glyphicon-chevron-left"></i></div>
-                        <div class="scroller scroller-right"><i class="glyphicon glyphicon-chevron-right"></i></div>
-                        <div class="wrapper">
-                            <ul class="nav nav-tabs list" role="tablist">
-                                <?php foreach ($spage->myShowPage() as $key => $page) { ?>
-                                    <li data-name="<?php echo $key?>" class="change-tab <?php echo $key == 'general' ? 'active' : ''?>"><a href="#<?php echo $key?>" aria-controls="<?php echo $key?>" role="tab" data-toggle="tab"><?php echo $page['name']?></a></li>
-                                <?php } ?>
-                            </ul>
-                        </div>
-                    </div>
-                    <div class="tab-content display">
-                        <?php foreach ($spage->myShowPage() as $key => $page) { ?>
-                            <div id="<?php echo $key?>" class="tab-pane <?php echo $key == 'general' ? 'active' : ''?>">
-                                <?php echo $page['content']?>
-                            </div>
-                        <?php } ?>
-                                        </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
-<!-- Modal alerts-->
-<div class="modal" id="hwalert" tabindex="-1" role="dialog" aria-labelledby="lhwalert">
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title" id="myModalLabel">Modal title</h4>
-      </div>
-      <div class="modal-body">
-        ...
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-      </div>
-    </div>
-  </div>
-</div>
+$display_page = $spage->myShowPage();
+$display_info = _("SCCP Server Settings");
+
+include('page.html.php');
+?>
 
 <!-- End Modal alerts-->

--- a/views/server.info.php
+++ b/views/server.info.php
@@ -14,6 +14,7 @@ $ast_realtime = $this->srvinterface->sccp_realtime_status();
 
 $ast_realm = (empty($ast_realtime['sccp']) ? '' : 'sccp');
 
+// if there are multiple connections, this will only return the first.
 foreach ($ast_realtime as $key => $value) {
     if (empty($ast_realm)) {
         if ($value['status'] == 'OK') {
@@ -61,7 +62,7 @@ if ($db_Schema == 0) {
 }
 
 if (empty($ast_realtime)) {
-    $info['RealTime'] = array('Version' => 'Error', 'about' => '<div class="alert signature alert-danger"> No found Real Time connections</div>');
+    $info['RealTime'] = array('Version' => 'Error', 'about' => '<div class="alert signature alert-danger"> No RealTime connections found</div>');
 } else {
     $rt_info = '';
     $rt_sccp = 'Failed';
@@ -82,7 +83,7 @@ if (empty($ast_realtime)) {
 }
 
 if (empty($conf_realtime)) {
-    $info['ConfigsRealTime'] = array('Version' => 'Error', 'about' => '<div class="alert signature alert-danger"> No found Real Time Configs</div>');
+    $info['ConfigsRealTime'] = array('Version' => 'Error', 'about' => '<div class="alert signature alert-danger"> Realtime configuration was not found</div>');
 } else {
     $rt_info = '';
     foreach ($conf_realtime as $key => $value) {
@@ -135,7 +136,7 @@ if ($test_any == 1) {
 //print_r(array_column($timezone_abbreviations, 'timezone_id'));
     print_r($Ts_set);
     $tz_tmp = array();
-        
+
     foreach ($timezone_abbreviations as $subArray) {
         $dddd  = array_search($Ts_set, array_column($subArray, 'timezone_id'));
         if (!empty($dddd)) {
@@ -157,7 +158,7 @@ if ($test_any == 1) {
             }
         }
     }
-    
+
     print_r("<br>");
 //print_r($time_set);
     print_r($this->sccpvalues['ntp_timezone']);
@@ -443,12 +444,12 @@ print(" ");
 //print_r($this->dbinterface->info());
 
 if (!empty($this->info_warning)) {
-    ?>    
+    ?>
     <div class="fpbx-container container-fluid">
         <div class="row">
             <div class="container">
                 <h2 style="border:2px solid Tomato;color:Tomato;" >Sccp Manager Warning</h2>
-                <div class="table-responsive">          
+                <div class="table-responsive">
                     <br> There are Warning in the SCCP Module:<br><pre>
                         <?php
                         foreach ($this->info_warning as $key => $value) {
@@ -472,12 +473,12 @@ if (!empty($this->info_warning)) {
 }
 
 if (!empty($this->class_error)) {
-    ?>    
+    ?>
     <div class="fpbx-container container-fluid">
         <div class="row">
             <div class="container">
                 <h2 style="border:2px solid Tomato;color:Tomato;" >Diagnostic information about SCCP Manager errors</h2>
-                <div class="table-responsive">          
+                <div class="table-responsive">
                     <br> There is an error in the :<br><pre>
     <?php print_r($this->class_error); ?>
                     </pre>
@@ -493,7 +494,7 @@ if (!empty($this->class_error)) {
     <div class="row">
         <div class="container">
             <h2>Sccp Manager V.<?php print_r($this->sccp_manager_ver); ?> Info </h2>
-            <div class="table-responsive">          
+            <div class="table-responsive">
                 <table class="table">
                     <thead>
                         <tr>
@@ -517,4 +518,3 @@ foreach ($info as $key => $value) {
     </div>
 </div>
 <?php echo $this->showGroup('sccp_info', 0); ?>
-

--- a/views/server.info.php
+++ b/views/server.info.php
@@ -12,7 +12,7 @@ $driver = $this->FreePBX->Core->getAllDriversInfo();
 $core = $this->srvinterface->getSCCPVersion();
 $ast_realtime = $this->srvinterface->sccp_realtime_status();
 
-$ast_realm = (empty($ast_realtime['sccp']) ? '' : 'sccp');
+//$ast_realm = (empty($ast_realtime['sccp']) ? '' : 'sccp');
 
 // if there are multiple connections, this will only return the first.
 foreach ($ast_realtime as $key => $value) {
@@ -70,13 +70,15 @@ if (empty($ast_realtime)) {
         if ($key == $ast_realm) {
             if ($value['status'] == 'OK') {
                 $rt_sccp = 'TEST OK';
-                $rt_info .= 'SCCP Connections found';
+                $rt_info .= '<div> Using SCCP connection found to database: '.$value['realm'] . ' with connector: ['. $key .']</div>';
             } else {
                 $rt_sccp = 'SCCP ERROR';
                 $rt_info .= '<div class="alert signature alert-danger"> Error : ' . $value['message'] . '</div>';
             }
         } elseif ($value['status'] == 'ERROR') {
-            $rt_info .= '<div> Found error in realtime sectoin [' . $key . '] : ' . $value['message'] . '</div>';
+            $rt_info .= '<div> No connector found for [' . $key . '] : ' . $value['message'] . '</div>';
+        } elseif ($value['status'] == 'OK') {
+            $rt_info .= '<div> Alternative connector found to database '.$value['realm'] . ' with connector: ['. $key . '] </div>';
         }
     }
     $info['RealTime'] = array('Version' => $rt_sccp, 'about' => $rt_info);


### PR DESCRIPTION
AddEvent in SCCPGeneric response closed without committing the retrieved table. 

This version ensures that the Table is closed correctly, and that the soft keys are returned when ami is enabled. It also checks that all of the content was received and returns nothing if the result is incomplete