### PR TITLE
Test for chan_sccp_b version compatibility

### DIFF
--- a/Sccp_manager.inc/aminterface/oldinterface.class.php
+++ b/Sccp_manager.inc/aminterface/oldinterface.class.php
@@ -306,7 +306,7 @@ class oldinterface
                         $result["vCode"] = 433;
                     } else {
                         $result["vCode"] = 430;
-                    }          
+                    }
                 }
             }
 

--- a/Sccp_manager.inc/srvinterface.class.php
+++ b/Sccp_manager.inc/srvinterface.class.php
@@ -15,6 +15,7 @@ class srvinterface {
     var $error;
     var $_info;
     var $ami_mode;
+    var $useAmiForSoftKeys = true;
 
     public function __construct($parent_class = null) {
         $this->paren_class = $parent_class;
@@ -206,24 +207,35 @@ class srvinterface {
 */        }
     }
 
-    public function get_compatible_sccp() {
-
+    public function get_compatible_sccp($revNumComp=false) {
+        // only called with args from installer to get revision and compatibility
         $res = $this->getSCCPVersion();
         if (empty($res)) {
             return 0;
         }
         switch ($res["vCode"]) {
             case 0:
-                return 0;
+                $retval = 0;
+                break;
             case 433:
-                return 433;
-
+                $retval = 433;
+                break;
             case 432:
+                $retval = 430;
+                break;
             case 431:
-                return 431;
+                $retval = 431;
+                break;
             default:
-                return 430;
+                $retval = 430;
         }
+        if ($res['RevisionNum'] < 11048) {
+            $this->useAmiForSoftKeys = false;
+        }
+        if ($revNumComp) {
+            return array($retval, $this->useAmiForSoftKeys);
+        }
+        return $retval;
     }
 
     public function getSCCPVersion() {
@@ -236,7 +248,7 @@ class srvinterface {
 
     public function sccp_list_keysets() {
 
-        if ($this->ami_mode) {
+        if (($this->ami_mode) && ($this->useAmiForSoftKeys)){
             return $this->aminterface->sccp_list_keysets();
         } else {
             return $this->oldinterface->sccp_list_keysets();

--- a/install.php
+++ b/install.php
@@ -17,7 +17,6 @@ global $astman;
 global $version;
 global $srvinterface;
 global $mobile_hw;
-global $useAmiForSoftKeys;
 $mobile_hw = '0';
 
 $class = "\\FreePBX\\Modules\\Sccp_manager\\srvinterface";

--- a/install.php
+++ b/install.php
@@ -17,6 +17,7 @@ global $astman;
 global $version;
 global $srvinterface;
 global $mobile_hw;
+global $useAmiForSoftKeys;
 $mobile_hw = '0';
 
 $class = "\\FreePBX\\Modules\\Sccp_manager\\srvinterface";
@@ -375,6 +376,7 @@ $table_req = array('sccpdevice', 'sccpline');
 $ss = FreePBX::create()->Sccp_manager;
 $astman = FreePBX::create()->astman;
 $sccp_compatible = 0;
+$chanSCCPWarning = true;
 //$db_config = $db_config_v0;
 $db_config = '';
 
@@ -445,13 +447,13 @@ function CheckAsteriskVersion()
 
 function CheckChanSCCPCompatible()
 {
+    global $chanSCCPWarning;
     global $srvinterface, $astman;
     if (!$astman) {
         ie_freepbx('No asterisk manager connection provided!. Installation Failed');
     }
-    $sccp_compatible = $srvinterface->get_compatible_sccp();
-    outn("<li>" . _("Sccp model Compatible code : ") . $sccp_compatible . "</li>");
-    return $sccp_compatible;
+    // calling with true returns array with compatibility and RevisionNumber
+    return $srvinterface->get_compatible_sccp(true);
 }
 
 function InstallDB_Buttons()
@@ -964,7 +966,11 @@ function Setup_RealTime()
 CheckSCCPManagerDBTables($table_req);
 #CheckPermissions();
 CheckAsteriskVersion();
-$sccp_compatible = CheckChanSCCPCompatible();
+$sccp_version = array();
+$sccp_version = CheckChanSCCPCompatible();
+$sccp_compatible = $sccp_version[0];
+$chanSCCPWarning = $sccp_version[1] ^= 1;
+outn("<li>" . _("Sccp model Compatible code : ") . $resultReturned[0] . "</li>");
 if ($sccp_compatible == 0) {
 //    die_freepbx('Chan Sccp not Found. Install it before continuing');
     outn("<br>");
@@ -995,6 +1001,11 @@ if (!$sccp_db_ver) {
 InstallDB_createButtonConfigTrigger();
 InstallDB_CreateSccpDeviceConfigView($sccp_compatible);
 InstallDB_updateDBVer($sccp_compatible);
+dbug('chanSCCPWarning',$chanSCCPWarning);
+if ($chanSCCPWarning) {
+    outn("<br>");
+    outn("<font color='red'>Warning: Upgrade chan_sccp_b to use full ami functionality</font>");
+}
 if (!$sccp_db_ver) {
     Setup_RealTime();
     outn("<br>");

--- a/views/server.info.php
+++ b/views/server.info.php
@@ -36,7 +36,8 @@ $info['aminterface'] = $this->aminterface->info();
 $info['XML'] = $this->xmlinterface->info();
 $info['sccp_class'] = $driver['sccp'];
 $info['Core_sccp'] = array('Version' => $core['Version'], 'about' => 'Sccp ver.' . $core['Version'] . ' r' . $core['vCode'] . ' Revision :' . $core['RevisionNum'] . ' Hash :' . $core['RevisionHash']);
-if (!$this->srvinterface->useAmiForSoftKeys) {
+if (!$this->srvinterface->useAmiInterface) {
+    $info['aminterface']['about'] .= ' -- Disabled';
     $info['Core_sccp'] = array('Version' => $core['Version'], 'about' => 'Sccp ver.' . $core['Version'] . ' r' . $core['vCode'] . ' Revision :' . $core['RevisionNum'] . ' Hash :' . $core['RevisionHash'] . ' ----Warning: Upgrade chan_sccp to use full ami functionality');
 }
 $info['Asterisk'] = array('Version' => FreePBX::Config()->get('ASTVERSION'), 'about' => 'Asterisk.');

--- a/views/server.info.php
+++ b/views/server.info.php
@@ -36,6 +36,9 @@ $info['aminterface'] = $this->aminterface->info();
 $info['XML'] = $this->xmlinterface->info();
 $info['sccp_class'] = $driver['sccp'];
 $info['Core_sccp'] = array('Version' => $core['Version'], 'about' => 'Sccp ver.' . $core['Version'] . ' r' . $core['vCode'] . ' Revision :' . $core['RevisionNum'] . ' Hash :' . $core['RevisionHash']);
+if (!$this->srvinterface->useAmiForSoftKeys) {
+    $info['Core_sccp'] = array('Version' => $core['Version'], 'about' => 'Sccp ver.' . $core['Version'] . ' r' . $core['vCode'] . ' Revision :' . $core['RevisionNum'] . ' Hash :' . $core['RevisionHash'] . ' ----Warning: Upgrade chan_sccp to use full ami functionality');
+}
 $info['Asterisk'] = array('Version' => FreePBX::Config()->get('ASTVERSION'), 'about' => 'Asterisk.');
 
 


### PR DESCRIPTION
SoftKeySets fails with chan_sccp-b and ami interface prior to chan_sccp_b revision 11048.

Check the version with the installer, and subsequently to ensure that do not get exception by using old interface for this method with earlier versions of chan_sccp_b (including the current release).

Thanks to @dkgroot for recommending and @rofferman for reporting.

additional cleaning thanks to Atom