### PR TITLE
Update dbinterface class to use PDO and fix some broken SQL.

### DIFF
--- a/Sccp_manager.class.php
+++ b/Sccp_manager.class.php
@@ -869,7 +869,7 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
                 }
                 break;
             case 'getDeviceModel':
-dbug('getting Device model');
+//dbug('getting Device model');
                 switch ($request['type']) {
                     case 'all':
                     case 'extension':
@@ -930,7 +930,7 @@ dbug('getting Device model');
                 return $result;
                 break;
             case 'getExtensionGrid':
-dbug('getting Extension Grid');
+//dbug('getting Extension Grid');
                 $result = $this->dbinterface->HWextension_db_SccpTableData('SccpExtension');
                 if (empty($result)) {
                     return array();
@@ -954,7 +954,7 @@ dbug('getting Extension Grid');
                 return $result;
                 break;
             case 'getPhoneGrid':
-dbug('getting Phone Grid');
+//dbug('getting Phone Grid');
                 $cmd_type = !empty($request['type']) ? $request['type'] : '';
 
                 $result = $this->dbinterface->HWextension_db_SccpTableData('SccpDevice', array('type' => $cmd_type));
@@ -1736,7 +1736,7 @@ dbug('getting Phone Grid');
             }
         }
 
-        $this->sccpvalues['sccp_compatible'] = array('keyword' => 'compatible', 'data' => $ver_id, 'type' => '1', 'seq' => '99');
+        $this->sccpvalues['sccp_compatible'] = array('keyword' => 'sccp_compatible', 'data' => $ver_id, 'type' => '1', 'seq' => '99');
         $this->sccppath = $this->extconfigs->validate_init_path($confDir, $this->sccpvalues, $sccp_driver_replace);
         $driver = $this->FreePBX->Core->getAllDriversInfo(); // ??????
 
@@ -2132,7 +2132,7 @@ dbug('getting Phone Grid');
             $dir_list = $this->findAllFiles($dir, $file_ext, 'fileonly');
         }
         $raw_settings = $this->dbinterface->getDb_model_info($get, $format_list, $filter);
-dbug('reloading table');
+//dbug('reloading table');
         if ($validate) {
             for ($i = 0; $i < count($raw_settings); $i++) {
                 $raw_settings[$i]['validate'] = '-;-';

--- a/Sccp_manager.class.php
+++ b/Sccp_manager.class.php
@@ -169,6 +169,7 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
             $this->xml_data = simplexml_load_file($xml_vars);
             $this->initVarfromXml(); // Overwrite Exist
         }
+        $this->saveSccpSettings();
     }
 
     /*
@@ -1483,10 +1484,7 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
     }
 
     public function getSccpSettingFromDB() {
-        $raw_data = $this->dbinterface->get_db_SccpSetting();
-        foreach ($raw_data as $var) {
-            $this->sccpvalues[$var['keyword']] = array('keyword' => $var['keyword'], 'data' => $var['data'], 'seq' => $var['seq'], 'type' => $var['type']);
-        }
+        $this->sccpvalues = $this->dbinterface->get_db_SccpSetting();
         return;
     }
 
@@ -1864,19 +1862,25 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
 //        global $db;
 //        global $amp_conf;
 
-        $save_settings = array();
+//        $save_settings = array();
         if (empty($save_value)) {
-            foreach ($this->sccpvalues as $key => $val) {
+            $this->dbinterface->write('sccpsettings', $this->sccpvalues, 'clear');
+
+/*            foreach ($this->sccpvalues as $key => $val) {
                 if ((trim($val['data']) !== '') or ($val['data'] == '0')) {
-                    $save_settings[] = array($key, $db->escapeSimple($val['data']), $val['seq'], $val['type']);
+                    $save_settings[] = array($key, $val['data'], $val['seq'], $val['type']);
+                } else {
+                    $unsaved_settings[] = array($key, $val['data'], $val['seq'], $val['type']);
                 }
             }
             $this->dbinterface->write('sccpsettings', $save_settings, 'clear');
+*/
         } else {
             $this->dbinterface->write('sccpsettings', $save_value, 'update');
-            return true;
         }
         return true;
+//        }
+//        return true;
     }
 
     /*

--- a/Sccp_manager.class.php
+++ b/Sccp_manager.class.php
@@ -875,7 +875,6 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
                 }
                 break;
             case 'getDeviceModel':
-//dbug('getting Device model');
                 switch ($request['type']) {
                     case 'all':
                     case 'extension':
@@ -936,7 +935,6 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
                 return $result;
                 break;
             case 'getExtensionGrid':
-//dbug('getting Extension Grid');
                 $result = $this->dbinterface->HWextension_db_SccpTableData('SccpExtension');
                 if (empty($result)) {
                     return array();
@@ -960,7 +958,6 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
                 return $result;
                 break;
             case 'getPhoneGrid':
-//dbug('getting Phone Grid');
                 $cmd_type = !empty($request['type']) ? $request['type'] : '';
 
                 $result = $this->dbinterface->HWextension_db_SccpTableData('SccpDevice', array('type' => $cmd_type));
@@ -1873,7 +1870,7 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
 
 //        $save_settings = array();
         if (empty($save_value)) {
-            $this->dbinterface->write('sccpsettings', $this->sccpvalues, 'replace');
+            $this->dbinterface->write('sccpsettings', $this->sccpvalues, 'replace'); //Change to replace as clearer
         } else {
             $this->dbinterface->write('sccpsettings', $save_value, 'update');
         }
@@ -2138,7 +2135,6 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
             $dir_list = $this->findAllFiles($dir, $file_ext, 'fileonly');
         }
         $raw_settings = $this->dbinterface->getDb_model_info($get, $format_list, $filter);
-//dbug('reloading table');
         if ($validate) {
             for ($i = 0; $i < count($raw_settings); $i++) {
                 $raw_settings[$i]['validate'] = '-;-';

--- a/Sccp_manager.class.php
+++ b/Sccp_manager.class.php
@@ -169,6 +169,7 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
             $this->xml_data = simplexml_load_file($xml_vars);
             $this->initVarfromXml(); // Overwrite Exist
         }
+        $this->saveSccpSettings();
     }
 
     /*
@@ -269,25 +270,25 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
     /* unused but FPBX API requires it */
 
     public function install() {
-        
+
     }
 
     /* unused but FPBX API requires it */
 
     public function uninstall() {
-        
+
     }
 
     /* unused but FPBX API requires it */
 
     public function backup() {
-        
+
     }
 
     /* unused but FPBX API requires it */
 
     public function restore($backup) {
-        
+
     }
 
     public function getActionBar($request) {
@@ -815,7 +816,7 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
                             $hw_list[] = array('name' => $idv);
                         }
                         if ($idv == 'all') {
-                            
+
                         }
                     }
                 }
@@ -1483,10 +1484,7 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
     }
 
     public function getSccpSettingFromDB() {
-        $raw_data = $this->dbinterface->get_db_SccpSetting();
-        foreach ($raw_data as $var) {
-            $this->sccpvalues[$var['keyword']] = array('keyword' => $var['keyword'], 'data' => $var['data'], 'seq' => $var['seq'], 'type' => $var['type']);
-        }
+        $this->sccpvalues = $this->dbinterface->get_db_SccpSetting();
         return;
     }
 
@@ -1864,19 +1862,25 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
 //        global $db;
 //        global $amp_conf;
 
-        $save_settings = array();
+//        $save_settings = array();
         if (empty($save_value)) {
-            foreach ($this->sccpvalues as $key => $val) {
+            $this->dbinterface->write('sccpsettings', $this->sccpvalues, 'clear');
+
+/*            foreach ($this->sccpvalues as $key => $val) {
                 if ((trim($val['data']) !== '') or ($val['data'] == '0')) {
-                    $save_settings[] = array($key, $db->escapeSimple($val['data']), $val['seq'], $val['type']);
+                    $save_settings[] = array($key, $val['data'], $val['seq'], $val['type']);
+                } else {
+                    $unsaved_settings[] = array($key, $val['data'], $val['seq'], $val['type']);
                 }
             }
             $this->dbinterface->write('sccpsettings', $save_settings, 'clear');
+*/
         } else {
             $this->dbinterface->write('sccpsettings', $save_value, 'update');
-            return true;
         }
         return true;
+//        }
+//        return true;
     }
 
     /*
@@ -2093,7 +2097,7 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
         }
         // [Namesoftkeyset]
         // type=softkeyset
-        // 
+        //
         // ----- It is a very bad idea to add an external configuration file "sccp_custom.conf" !!!!
         // This will add problems when solving problems caused by unexpected solutions from users.
         //

--- a/Sccp_manager.class.php
+++ b/Sccp_manager.class.php
@@ -869,7 +869,7 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
                 }
                 break;
             case 'getDeviceModel':
-dbug('getting Device model');
+//dbug('getting Device model');
                 switch ($request['type']) {
                     case 'all':
                     case 'extension':
@@ -930,7 +930,7 @@ dbug('getting Device model');
                 return $result;
                 break;
             case 'getExtensionGrid':
-dbug('getting Extension Grid');
+//dbug('getting Extension Grid');
                 $result = $this->dbinterface->HWextension_db_SccpTableData('SccpExtension');
                 if (empty($result)) {
                     return array();
@@ -954,7 +954,7 @@ dbug('getting Extension Grid');
                 return $result;
                 break;
             case 'getPhoneGrid':
-dbug('getting Phone Grid');
+//dbug('getting Phone Grid');
                 $cmd_type = !empty($request['type']) ? $request['type'] : '';
 
                 $result = $this->dbinterface->HWextension_db_SccpTableData('SccpDevice', array('type' => $cmd_type));
@@ -2132,7 +2132,7 @@ dbug('getting Phone Grid');
             $dir_list = $this->findAllFiles($dir, $file_ext, 'fileonly');
         }
         $raw_settings = $this->dbinterface->getDb_model_info($get, $format_list, $filter);
-dbug('reloading table');
+//dbug('reloading table');
         if ($validate) {
             for ($i = 0; $i < count($raw_settings); $i++) {
                 $raw_settings[$i]['validate'] = '-;-';

--- a/Sccp_manager.class.php
+++ b/Sccp_manager.class.php
@@ -269,25 +269,25 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
     /* unused but FPBX API requires it */
 
     public function install() {
-        
+
     }
 
     /* unused but FPBX API requires it */
 
     public function uninstall() {
-        
+
     }
 
     /* unused but FPBX API requires it */
 
     public function backup() {
-        
+
     }
 
     /* unused but FPBX API requires it */
 
     public function restore($backup) {
-        
+
     }
 
     public function getActionBar($request) {
@@ -815,7 +815,7 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
                             $hw_list[] = array('name' => $idv);
                         }
                         if ($idv == 'all') {
-                            
+
                         }
                     }
                 }
@@ -1735,7 +1735,7 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
             }
         }
 
-        $this->sccpvalues['sccp_compatible'] = array('keyword' => 'compatible', 'data' => $ver_id, 'type' => '1', 'seq' => '99');
+        $this->sccpvalues['sccp_compatible'] = array('keyword' => 'sccp_compatible', 'data' => $ver_id, 'type' => '1', 'seq' => '99');
         $this->sccppath = $this->extconfigs->validate_init_path($confDir, $this->sccpvalues, $sccp_driver_replace);
         $driver = $this->FreePBX->Core->getAllDriversInfo(); // ??????
 
@@ -2093,7 +2093,7 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
         }
         // [Namesoftkeyset]
         // type=softkeyset
-        // 
+        //
         // ----- It is a very bad idea to add an external configuration file "sccp_custom.conf" !!!!
         // This will add problems when solving problems caused by unexpected solutions from users.
         //

--- a/Sccp_manager.class.php
+++ b/Sccp_manager.class.php
@@ -1165,7 +1165,7 @@ dbug('getting Phone Grid');
         $save_settings = array();
         $save_codec = array();
         $name_dev = '';
-        $db_field = $this->dbinterface->HWextension_db_SccpTableData("get_colums_sccpdevice");
+        $db_field = $this->dbinterface->HWextension_db_SccpTableData("get_columns_sccpdevice");
         $hw_id = (empty($get_settings['sccp_deviceid'])) ? 'new' : $get_settings['sccp_deviceid'];
         $hw_type = (empty($get_settings['sccp_device_typeid'])) ? 'sccpdevice' : $get_settings['sccp_device_typeid'];
         $update_hw = ($hw_id == 'new') ? 'update' : 'clear';
@@ -1407,7 +1407,7 @@ dbug('getting Phone Grid');
           );
          */
         $name_dev = '';
-        $db_field = $this->dbinterface->HWextension_db_SccpTableData("get_colums_sccpuser");
+        $db_field = $this->dbinterface->HWextension_db_SccpTableData("get_columns_sccpuser");
         // $hw_id = (empty($get_settings['sccp_deviceid'])) ? 'new' : $get_settings['sccp_deviceid'];
         // $update_hw = ($hw_id == 'new') ? 'update' : 'clear';
         $hw_prefix = 'SEP';

--- a/Sccp_manager.class.php
+++ b/Sccp_manager.class.php
@@ -869,6 +869,7 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
                 }
                 break;
             case 'getDeviceModel':
+dbug('getting Device model');
                 switch ($request['type']) {
                     case 'all':
                     case 'extension':
@@ -929,6 +930,7 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
                 return $result;
                 break;
             case 'getExtensionGrid':
+dbug('getting Extension Grid');
                 $result = $this->dbinterface->HWextension_db_SccpTableData('SccpExtension');
                 if (empty($result)) {
                     return array();
@@ -952,6 +954,7 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
                 return $result;
                 break;
             case 'getPhoneGrid':
+dbug('getting Phone Grid');
                 $cmd_type = !empty($request['type']) ? $request['type'] : '';
 
                 $result = $this->dbinterface->HWextension_db_SccpTableData('SccpDevice', array('type' => $cmd_type));
@@ -1865,22 +1868,10 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
 //        $save_settings = array();
         if (empty($save_value)) {
             $this->dbinterface->write('sccpsettings', $this->sccpvalues, 'clear');
-
-/*            foreach ($this->sccpvalues as $key => $val) {
-                if ((trim($val['data']) !== '') or ($val['data'] == '0')) {
-                    $save_settings[] = array($key, $val['data'], $val['seq'], $val['type']);
-                } else {
-                    $unsaved_settings[] = array($key, $val['data'], $val['seq'], $val['type']);
-                }
-            }
-            $this->dbinterface->write('sccpsettings', $save_settings, 'clear');
-*/
         } else {
             $this->dbinterface->write('sccpsettings', $save_value, 'update');
         }
         return true;
-//        }
-//        return true;
     }
 
     /*
@@ -2140,9 +2131,8 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
         } else {
             $dir_list = $this->findAllFiles($dir, $file_ext, 'fileonly');
         }
-
         $raw_settings = $this->dbinterface->getDb_model_info($get, $format_list, $filter);
-
+dbug('reloading table');
         if ($validate) {
             for ($i = 0; $i < count($raw_settings); $i++) {
                 $raw_settings[$i]['validate'] = '-;-';

--- a/Sccp_manager.inc/aminterface/oldinterface.class.php
+++ b/Sccp_manager.inc/aminterface/oldinterface.class.php
@@ -306,7 +306,7 @@ class oldinterface
                         $result["vCode"] = 433;
                     } else {
                         $result["vCode"] = 430;
-                    }          
+                    }
                 }
             }
 

--- a/Sccp_manager.inc/dbinterface.class.php
+++ b/Sccp_manager.inc/dbinterface.class.php
@@ -31,20 +31,21 @@ class dbinterface
      */
     public function get_db_SccpTableByID($dataid, $data = array(), $indexField = '')
     {
-        $resut = array();
+        $result = array();
         $raw = $this->HWextension_db_SccpTableData($dataid, $data);
         if (empty($raw) || empty($indexField)) {
             return $raw;
         }
         foreach ($raw as $value) {
             $id = $value[$indexField];
-            $resut[$id] = $value;
+            $result[$id] = $value;
         }
         return $resut;
     }
 
     public function HWextension_db_SccpTableData($dataid, $data = array())
     {
+        // $stmt is a single row fetch, $stmts is a fetchAll.
         global $db;
         $stmt = '';
         $stmts = '';
@@ -52,14 +53,14 @@ class dbinterface
             return false;
         }
         switch ($dataid) {
-            case "SccpExtension":
+            case 'SccpExtension':
                 if (empty($data['name'])) {
                     $stmts = $db->prepare('SELECT * FROM sccpline ORDER BY name');
                 } else {
                     $stmts = $db->prepare('SELECT * FROM sccpline WHERE name = $data[name]');
                 }
                 break;
-            case "SccpDevice":
+            case 'SccpDevice':
                 $filtered ='';
                 $singlerow = false;
                 if (empty($data['fields'])) {
@@ -103,20 +104,20 @@ class dbinterface
                     $stmts = $db->prepare($sql);
                 }
                 break;
-            case "HWSipDevice":
+            case 'HWSipDevice':
                 $raw_settings = $this->getDb_model_info($get = "sipphones", $format_list = "model");
                 break;
-            case "HWDevice":
+            case 'HWDevice':
                 $raw_settings = $this->getDb_model_info($get = "ciscophones", $format_list = "model");
                 break;
-            case "HWextension":
+            case 'HWextension':
                 $raw_settings = $this->getDb_model_info($get = "extension", $format_list = "model");
                 break;
-            case "get_colums_sccpdevice":
+            case 'get_colums_sccpdevice':
                 $sql = "DESCRIBE sccpdevice";
                 $stmt = $db->prepare($sql);
                 break;
-            case "get_colums_sccpuser":
+            case 'get_colums_sccpuser':
                 $sql = "DESCRIBE sccpuser";
                 $stmts = $db->prepare($sql);
                 break;
@@ -127,7 +128,7 @@ class dbinterface
                         . 'LEFT JOIN sccpdevmodel as addon ON t1.addon=addon.model WHERE name="' . $data['id'] . '';
                 $stmt = $db->prepare($sql);
                 break;
-            case "get_sccpuser":
+            case 'get_sccpuser':
                 $sql = 'SELECT * FROM sccpuser ';
                 if (!empty($data['id'])) {
                     $sql .= 'WHERE name= ' . $data['id'] . '';
@@ -135,13 +136,13 @@ class dbinterface
                 $sql .= ' ORDER BY name';
                 $stmt = $db->prepare($sql);
                 break;
-            case "get_sccpdevice_buttons":
+            case 'get_sccpdevice_buttons':
                 $sql = '';
                 if (!empty($data['buttontype'])) {
                     $sql .= 'buttontype="' . $data['buttontype'] . '" ';
                 }
                 if (!empty($data['id'])) {
-                    $sql .= (empty($sql)) ? 'ref="' . $data['id'] . '" ' : 'and ref="' . $data['id'] . '" ';
+                    $sql .= (empty($sql)) ? 'ref="' . $data['id'] . '" ' : 'and ref="' . $data['id'] . '';
                 }
                 if (!empty($sql)) {
                     $sql = 'SELECT * FROM sccpbuttonconfig WHERE ' .$sql. ' ORDER BY `instance`;';
@@ -204,7 +205,7 @@ class dbinterface
                         if (strpos($filter['model'], 'loadInformation')) {
                             $sql = 'SELECT ' . $sel_inf . ' FROM sccpdevmodel WHERE (loadinformationid =' . $filter['model'] . ') ORDER BY model';
                         } else {
-                            $sql = 'SELECT ' . $sel_inf . ' FROM sccpdevmodel WHERE (loadinformationid =loadInformation' . $filter['model'] . ') ORDER BY model';
+                            $sql = 'SELECT ' . $sel_inf . ' FROM sccpdevmodel WHERE (loadinformationid = loadInformation' . $filter['model'] . ') ORDER BY model';
                         }
                     } else {
 //                          $sql = "SELECT ".$filter['model'];
@@ -326,36 +327,32 @@ class dbinterface
                 $result = $db->prepare($req)->execute();
                 break;
             case 'sccpbuttons':
-                if (($mode == 'clear') || ($mode == 'delete')) {
-                    $sql = 'DELETE FROM sccpbuttonconfig WHERE ref=' . $hwid . '';
-                    $result = $db->prepare($sql)->execute();
+                switch ($mode) {
+                    case 'clear':   // no break here as clear is same as delete
+                    case 'delete':
+                        $sql = 'DELETE FROM sccpbuttonconfig WHERE ref=' . $hwid . '';
+                        $result = $db->prepare($sql)->execute();
+                        break;
+                    case 'replace':
+                        if (!empty($save_value)) {
+                            $sql = 'UPDATE sccpbuttonconfig SET `name`=? WHERE  `ref`= ? AND `reftype`=? AND `instance`=?  AND `buttontype`=?';
+                            $stmt = $db->prepare($sql);
+                            $result= $db->executeMultiple($stmt, $save_value);
+                        }
+                        break;
+                    default:
+                        if (!empty($save_value)) {
+                            $sql = 'INSERT INTO sccpbuttonconfig (`ref`, `reftype`,`instance`, `buttontype`, `name`, `options`) VALUES (?,?,?,?,?,?)';
+                            $stmt = $db->prepare($sql);
+                            $result = $db->executeMultiple($stmt, $save_value);
+                        }
                 }
-                if ($mode == 'delete') {
-                    break;
-                }
-                if (empty($save_value)) {
-                    break;
-                }
-                if ($mode == 'replace') {
-                    $sql = 'UPDATE sccpbuttonconfig SET `name`=? WHERE  `ref`= ? AND `reftype`=? AND `instance`=?  AND `buttontype`=?';
-//                    $sql = 'INSERT INTO `sccpbuttonconfig` (`ref`, `reftype`,`instance`, `buttontype`, `name`, `options`) VALUES (?,?,?,?,?,?);';
-//                    die(print_r($save_value,1));
-                    $stmt = $db->prepare($sql);
-                    $result= $db->executeMultiple($stmt, $save_value);
-                } else {
-                    $sql = 'INSERT INTO sccpbuttonconfig (`ref`, `reftype`,`instance`, `buttontype`, `name`, `options`) VALUES (?,?,?,?,?,?)';
-//                    die(print_r($save_value,1));
-                    $stmt = $db->prepare($sql);
-                    $result = $db->executeMultiple($stmt, $save_value);
-                }
-
-                break;
         }
         return $result;
     }
 
     /*
-     *  My be Replace by SccpTables ??!
+     *  Maybe Replace by SccpTables ??!
      *
      */
     public function dump_sccp_tables($data_path, $database, $user, $pass)

--- a/Sccp_manager.inc/dbinterface.class.php
+++ b/Sccp_manager.inc/dbinterface.class.php
@@ -150,12 +150,30 @@ class dbinterface
     public function get_db_SccpSetting()
     {
         global $db;
-        $stmt = $db->prepare('SELECT keyword, data, type, seq FROM sccpsettings ORDER BY type, seq');
-        $stmt->execute();
-        foreach ($stmt->fetchAll() as $var) {
-            $mysccpvalues[$var['keyword']] = array('keyword' => $var['keyword'], 'data' => $var['data'], 'seq' => $var['seq'], 'type' => $var['type']);
+        try {
+            $stmt = $db->prepare('SELECT keyword, data, type, seq FROM sccpsettings ORDER BY type, seq');
+            $stmt->execute();
+            foreach ($stmt->fetchAll() as $var) {
+                $mysccpvalues[$var['keyword']] = array('keyword' => $var['keyword'], 'data' => $var['data'], 'seq' => $var['seq'], 'type' => $var['type']);
+            }
+            return $mysccpvalues;
+        } catch(\PDOException $e) {
+            // sccpsettings table does not yet exist. FreePBX is instantiating
+            // a SCCP_Manager object from the Installer before the installer can
+            // create the table so will create here.
+            $stmt = $db-> prepare('CREATE TABLE IF NOT EXISTS sccpsettings (
+                    keyword VARCHAR (50) NOT NULL,
+                    data    VARCHAR (255) NOT NULL,
+                    seq     TINYINT (1),
+                    type    TINYINT (1) NOT NULL default 0,
+                    PRIMARY KEY (keyword, seq, type )
+                    );');
+            $check = $stmt->execute();
+            if (\DB::IsError($check)) {
+                die_freepbx("Can not create sccpsettings table, error: $check\n");
+            }
+            return array();
         }
-        return $mysccpvalues;
     }
 
     public function get_db_sysvalues()

--- a/Sccp_manager.inc/dbinterface.class.php
+++ b/Sccp_manager.inc/dbinterface.class.php
@@ -308,7 +308,7 @@ class dbinterface
                             $stmt = $dbh->prepare('UPDATE ' . $table_name . ' SET ' . $sql_var . ' WHERE ' . $sql_key);
                             break;
                         case 'replace':
-                            $stmt = $dbh->prepare('REPLACE INTO ' . $table_name . ' VALUES ' . $sql_var);
+                            $stmt = $dbh->prepare('REPLACE INTO ' . $table_name . ' SET ' . $sql_var);
                             break;
                         // no default mode - must be explicit.
                     }

--- a/Sccp_manager.inc/dbinterface.class.php
+++ b/Sccp_manager.inc/dbinterface.class.php
@@ -40,7 +40,7 @@ class dbinterface
             $id = $value[$indexField];
             $result[$id] = $value;
         }
-        return $resut;
+        return $result;
     }
 
     public function HWextension_db_SccpTableData($dataid, $data = array())

--- a/Sccp_manager.inc/dbinterface.class.php
+++ b/Sccp_manager.inc/dbinterface.class.php
@@ -58,7 +58,7 @@ class dbinterface
                     $stmts = $dbh->prepare('SELECT * FROM sccpline ORDER BY name');
                 } else {
                     $stmts = $dbh->prepare('SELECT * FROM sccpline WHERE name = :name');
-                    $stmt->bindParam(':name', $data['name'],\PDO::PARAM_STR);
+                    $stmts->bindParam(':name', $data['name'],\PDO::PARAM_STR);
                 }
                 break;
             case 'SccpDevice':

--- a/Sccp_manager.inc/srvinterface.class.php
+++ b/Sccp_manager.inc/srvinterface.class.php
@@ -15,6 +15,7 @@ class srvinterface {
     var $error;
     var $_info;
     var $ami_mode;
+    var $useAmiForSoftKeys = true;
 
     public function __construct($parent_class = null) {
         $this->paren_class = $parent_class;
@@ -206,24 +207,35 @@ class srvinterface {
 */        }
     }
 
-    public function get_compatible_sccp() {
-
+    public function get_compatible_sccp($revNumComp=false) {
+        // only called with args from installer to get revision and compatibility
         $res = $this->getSCCPVersion();
         if (empty($res)) {
             return 0;
         }
         switch ($res["vCode"]) {
             case 0:
-                return 0;
+                $retval = 0;
+                break;
             case 433:
-                return 433;
-
+                $retval = 433;
+                break;
             case 432:
+                $retval = 430;
+                break;
             case 431:
-                return 431;
+                $retval = 431;
+                break;
             default:
-                return 430;
+                $retval = 430;
         }
+        if ($res['RevisionNum'] < 11048) {
+            $this->useAmiForSoftKeys = false;
+        }
+        if ($revNumComp) {
+            return array($retval, $this->useAmiForSoftKeys);
+        }
+        return $retval;
     }
 
     public function getSCCPVersion() {
@@ -236,7 +248,7 @@ class srvinterface {
 
     public function sccp_list_keysets() {
 
-        if ($this->ami_mode) {
+        if (($this->ami_mode) && ($this->useAmiForSoftKeys)){
             return $this->aminterface->sccp_list_keysets();
         } else {
             return $this->oldinterface->sccp_list_keysets();

--- a/assets/js/sccp_manager.js
+++ b/assets/js/sccp_manager.js
@@ -241,7 +241,7 @@ $(document).ready(function () {
         }
         e.preventDefault();
     });
-    
+
 // Form.buttons - Form.adddevice
     $('.futuretype').change(function (e) {
         var kid = $(this).data('id');
@@ -256,7 +256,7 @@ $(document).ready(function () {
                 }
             }
         });
-        
+
     });
 
     $('.buttontype').change(function (e) {
@@ -627,7 +627,7 @@ $(document).ready(function () {
                     i++;
                 });
             }
-            
+
             if (datas === '') {
                 if (confirm(conf_msg)) {
                     datas = 'name[0]=all';
@@ -692,7 +692,7 @@ $(document).ready(function () {
 //});
 
 
-//    Bootstrap table Enabled / Disabled buttons ( class="btn-tab-select")
+//    Bootstrap table Enable / Disable buttons ( class="btn-tab-select")
 $("table").on('check-all.bs.table', function (rows) {
     var id_fld = $(this).data('id');
     $(".btn-tab-select").each(function () {
@@ -1011,7 +1011,7 @@ function bs_page_reload()
 }
 function bs_alert(data, status, reload)
 {
-    
+
     if (document.getElementById('hwalert') === null) {
         if (Array.isArray(data)) {
             data.forEach(function (entry) {
@@ -1075,4 +1075,3 @@ function sleep(milliseconds)
         }
     }
 }
-

--- a/install.php
+++ b/install.php
@@ -1001,7 +1001,6 @@ if (!$sccp_db_ver) {
 InstallDB_createButtonConfigTrigger();
 InstallDB_CreateSccpDeviceConfigView($sccp_compatible);
 InstallDB_updateDBVer($sccp_compatible);
-dbug('chanSCCPWarning',$chanSCCPWarning);
 if ($chanSCCPWarning) {
     outn("<br>");
     outn("<font color='red'>Warning: Upgrade chan_sccp_b to use full ami functionality</font>");

--- a/install.php
+++ b/install.php
@@ -17,6 +17,7 @@ global $astman;
 global $version;
 global $srvinterface;
 global $mobile_hw;
+global $useAmiForSoftKeys;
 $mobile_hw = '0';
 
 $class = "\\FreePBX\\Modules\\Sccp_manager\\srvinterface";
@@ -375,6 +376,7 @@ $table_req = array('sccpdevice', 'sccpline');
 $ss = FreePBX::create()->Sccp_manager;
 $astman = FreePBX::create()->astman;
 $sccp_compatible = 0;
+$chanSCCPWarning = true;
 //$db_config = $db_config_v0;
 $db_config = '';
 
@@ -445,13 +447,13 @@ function CheckAsteriskVersion()
 
 function CheckChanSCCPCompatible()
 {
+    global $chanSCCPWarning;
     global $srvinterface, $astman;
     if (!$astman) {
         ie_freepbx('No asterisk manager connection provided!. Installation Failed');
     }
-    $sccp_compatible = $srvinterface->get_compatible_sccp();
-    outn("<li>" . _("Sccp model Compatible code : ") . $sccp_compatible . "</li>");
-    return $sccp_compatible;
+    // calling with true returns array with compatibility and RevisionNumber
+    return $srvinterface->get_compatible_sccp(true);
 }
 
 function InstallDB_Buttons()
@@ -964,7 +966,11 @@ function Setup_RealTime()
 CheckSCCPManagerDBTables($table_req);
 #CheckPermissions();
 CheckAsteriskVersion();
-$sccp_compatible = CheckChanSCCPCompatible();
+$sccp_version = array();
+$sccp_version = CheckChanSCCPCompatible();
+$sccp_compatible = $sccp_version[0];
+$chanSCCPWarning = $sccp_version[1] ^= 1;
+outn("<li>" . _("Sccp model Compatible code : ") . $resultReturned[0] . "</li>");
 if ($sccp_compatible == 0) {
 //    die_freepbx('Chan Sccp not Found. Install it before continuing');
     outn("<br>");
@@ -995,6 +1001,11 @@ if (!$sccp_db_ver) {
 InstallDB_createButtonConfigTrigger();
 InstallDB_CreateSccpDeviceConfigView($sccp_compatible);
 InstallDB_updateDBVer($sccp_compatible);
+dbug('chanSCCPWarning',$chanSCCPWarning);
+if ($chanSCCPWarning) {
+    outn("<br>");
+    outn("<font color='red'>Warning: Upgrade chan_sccp_b to use full ami functionality</font>");
+}
 if (!$sccp_db_ver) {
     Setup_RealTime();
     outn("<br>");

--- a/install.php
+++ b/install.php
@@ -27,7 +27,6 @@ if (!class_exists($class, false)) {
 if (class_exists($class, false)) {
     $srvinterface = new $class();
 }
-
 function Get_DB_config($sccp_compatible)
 {
     global $mobile_hw;
@@ -484,16 +483,16 @@ function InstallDB_sccpsettings()
 {
     global $db;
     outn("<li>" . _("Creating sccpsettings table...") . "</li>");
-    $sql = "CREATE TABLE IF NOT EXISTS `sccpsettings` (
-            `keyword` VARCHAR (50) NOT NULL default '',
-            `data`    VARCHAR (255) NOT NULL default '',
-            `seq`     TINYINT (1),
-            `type`    TINYINT (1) NOT NULL default '0',
-            PRIMARY KEY (`keyword`,`seq`,`type`)
-    );";
-    $check = $db->query($sql);
+    $stmt = $db-> prepare('CREATE TABLE IF NOT EXISTS sccpsettings (
+            keyword VARCHAR (50) NOT NULL,
+            data    VARCHAR (255) NOT NULL,
+            seq     TINYINT (1),
+            type    TINYINT (1) NOT NULL,
+            PRIMARY KEY (keyword, seq, type )
+          );');
+    $check = $stmt->execute();
     if (DB::IsError($check)) {
-        die_freepbx("Can not create sccpsettings table, error:$check\n");
+        die_freepbx("Can not create sccpsettings table, error: $check\n");
     }
     return true;
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -56,6 +56,14 @@ if (!empty($version)) {
         sql("DELETE FROM kvstore WHERE module = 'sccpsettings'");
         sql("DELETE FROM kvstore WHERE module = 'Sccp_manager'");
     }
+    // By accessing the database, we have recreated sccpsettings table so now delete
+    // Need to rewrite this uninstaller.
+    $sql = "DROP TABLE IF EXISTS sccpsettings";
+    $result = $db->query($sql);
+    if (DB::IsError($result)) {
+        die_freepbx($result->getDebugInfo());
+    }
+    unset($result);
 
 /* Comment: Maybe save in sccpsettings, if the chan_sccp tables already existed in the database or if they were created by install.php */
 /* So that you know if it is safe to drop/delete them */

--- a/views/advserver.model.php
+++ b/views/advserver.model.php
@@ -13,12 +13,13 @@
 
             <div class="display no-border">
                 <div id="toolbar-model">
-                    <button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target=".add_new_model"><i class="fa fa-bolt"></i> <?php echo _("Add model"); ?></button>
+                    <button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target=".add_new_model"><i class="fa fa-bolt"></i> <?php echo _("Add model"); ?>
+                    </button>
                     <button data-id="model_disabled" class="btn btn-danger sccp_update btn-tab-select" data-type="sccp_model" data-table="table-models" disabled data-section="all">
-                        <i class="glyphicon glyphicon-remove"></i> <span><?php echo _('Disabled') ?></span>
+                        <i class="glyphicon glyphicon-remove"></i> <span><?php echo _('Disable') ?></span>
                     </button>
                     <button data-id="model_enabled" class="btn btn-danger sccp_update btn-tab-select" data-table="table-models" data-type="sccp_model" disabled data-section="all">
-                        <i class="glyphicon glyphicon-active"></i> <span><?php echo _('Enabled') ?></span>
+                        <i class="glyphicon glyphicon-active"></i> <span><?php echo _('Enable') ?></span>
                     </button>
                     <div class="btn-group">
                         <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
@@ -27,8 +28,8 @@
                         </a>
                         <ul class="dropdown-menu">
                             <li><a class="dropitem" data-id="enabled" tabindex="-1" href="#"><span><?php echo _('Show Enabled') ?></span></a></li>
-                            <li><a class="dropitem" data-id="extension" tabindex="-1" href="#"><span><?php echo _('Expansion Module')?></span></a></li>                            
-                            <li><a class="dropitem" data-id="all" tabindex="-1" href="#"><span><?php echo _('Show All') ?></span></a></li>                            
+                            <li><a class="dropitem" data-id="extension" tabindex="-1" href="#"><span><?php echo _('Expansion Module')?></span></a></li>
+                            <li><a class="dropitem" data-id="all" tabindex="-1" href="#"><span><?php echo _('Show All') ?></span></a></li>
                         </ul>
                     </div>
                 </div>
@@ -108,8 +109,8 @@
                     <div class="row"><div class="col-md-12">
                         <span id="new_buttons-help" class="help-block fpbx-help-block">Help.</span>
                 </div></div></div>
-                
-                
+
+
                 <div class="element-container"><div class="row"> <div class="form-group"><div class="col-md-3">
                         <label class="control-label" for="new_loadimage"><?php echo _('Load Image');?></label>
                         <i class="fa fa-question-circle fpbx-help-icon" data-for="new_loadimage"></i>
@@ -129,7 +130,7 @@
                     <div class="row"><div class="col-md-12">
                         <span id="new_loadinformationid-help" class="help-block fpbx-help-block">Help.</span>
                 </div></div></div>
-                
+
                 <div class="element-container"><div class="row"> <div class="form-group"><div class="col-md-3">
                         <label class="control-label" for="new_nametemplate"><?php echo _('Model template XML');?></label>
                         <i class="fa fa-question-circle fpbx-help-icon" data-for="new_nametemplate"></i>
@@ -143,7 +144,7 @@
             <div class="modal-footer">
                 <button type="button" class="btn btn-default" data-dismiss="modal"><?php echo _('Close');?></button>
                 <button type="button" class="btn btn-primary sccp_update" data-id="model_add" id="add_new_model" data-dismiss="modal"><?php echo _('Add New model without Enabled');?></button>
-            </div>            
+            </div>
         </div>
     </div>
 </div>
@@ -169,7 +170,7 @@
                         <span id="editd_model-help" class="help-block fpbx-help-block">Help.</span>
                 </div></div></div>
 
-                
+
                 <div class="element-container"><div class="row"> <div class="form-group"><div class="col-md-3">
                         <label class="control-label" for="editd_loadimage"><?php echo _('Load Image');?></label>
                         <i class="fa fa-question-circle fpbx-help-icon" data-for="edit_devimage"></i>
@@ -190,12 +191,12 @@
                         <span id="editd_nametemplate-help" class="help-block fpbx-help-block">Help.</span>
                 </div></div></div>
 
-                
+
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-default" data-dismiss="modal"><?php echo _('Close');?></button>
                 <button type="button" class="btn btn-primary sccp_update" data-id="model_apply" data-dismiss="modal"><?php echo _('apply');?></button>
-            </div>            
+            </div>
         </div>
     </div>
 </div>
@@ -214,7 +215,7 @@
 //    function DispayInputFormatter(value, row, index) {
 //        return  (value == null) ?  '<input class="tabl-edit form-control" name="' + row['model'] + '_template" type="text" value="">'  : '<input class="tabl-edit form-control" name="' + row['model'] + '_template" type="text" value="' + value + '">';
 //    }
-    
+
     function DispayActionsModelFormatter(value, row, index) {
         var exp_model = '';
 //        exp_model += '<a href="#edit_model"   class="btn btn-info"   onclick="load_model(this, &quot;'+row['model']+'&quot;)" data-toggle="modal"><i class="fa fa-pencil"></i></a>';
@@ -236,12 +237,12 @@
         return value;
 
     }
-    
+
     function SetRowColor(row, index) {
         var tclass = "active";
         if (row['enabled'] === 1) {
             tclass = (index % 2 === 0) ? "info" : "info";
-        }    
+        }
         if ((row['validate'] === 'yes;yes') || (row['validate'] === 'yes;-')) {
 //            tclass = (row['enabled'] === '1') ?  "danger" : "warning";
         } else {
@@ -249,7 +250,7 @@
         }
         return {classes: tclass};
     }
-    
+
     function load_model(elmnt,clr) {
 //        $("#edit_devmodel").text(clr);
         var drow = $("#table-models").bootstrapTable('getRowByUniqueId',clr);

--- a/views/server.info.php
+++ b/views/server.info.php
@@ -36,6 +36,9 @@ $info['aminterface'] = $this->aminterface->info();
 $info['XML'] = $this->xmlinterface->info();
 $info['sccp_class'] = $driver['sccp'];
 $info['Core_sccp'] = array('Version' => $core['Version'], 'about' => 'Sccp ver.' . $core['Version'] . ' r' . $core['vCode'] . ' Revision :' . $core['RevisionNum'] . ' Hash :' . $core['RevisionHash']);
+if (!$this->srvinterface->useAmiForSoftKeys) {
+    $info['Core_sccp'] = array('Version' => $core['Version'], 'about' => 'Sccp ver.' . $core['Version'] . ' r' . $core['vCode'] . ' Revision :' . $core['RevisionNum'] . ' Hash :' . $core['RevisionHash'] . ' ----Warning: Upgrade chan_sccp to use full ami functionality');
+}
 $info['Asterisk'] = array('Version' => FreePBX::Config()->get('ASTVERSION'), 'about' => 'Asterisk.');
 
 


### PR DESCRIPTION
Update to PDO model. Improves clarity and eliminates need for unnecessary quoting.

Restructure to improve readability

Modify calls to dbinterface class to reduce post processing

Use PDO bindParam to speed execution and ensure data integrity

Save sccpsettings to DB after initial constructor call in Sccp_manager class

Fix some broken SQL statements.

Add some annotations to help in future

Atom whitespace removal
