### PR TITLE
Switching asmanager: 'enabled' to 'off'

### DIFF
--- a/Sccp_manager.inc/aminterface/aminterface.class.php
+++ b/Sccp_manager.inc/aminterface/aminterface.class.php
@@ -54,7 +54,7 @@ class aminterface
         $this->_socket = false;
         $this->_connect_state = false;
         $this->_error = array();
-        $this->_config = array('host' => 'localhost', 'user' => '', 'pass' => '', 'port' => '5038', 'tsoket' => 'tcp://', 'timeout' => 30, 'enabled' => true);
+        $this->_config = array('host' => 'localhost', 'user' => '', 'pass' => '', 'port' => '5038', 'tsoket' => 'tcp://', 'timeout' => 30, 'enabled' => false);
         $this->_eventListeners = array();
 //  $this->_eventFactory = new EventFactoryImpl(\Logger::getLogger('EventFactory'));
 //  $this->_responseFactory = new ResponseFactoryImpl(\Logger::getLogger('ResponseFactory'));


### PR DESCRIPTION
Not exactly sure what ;enabled; controls, but it seems to switch of some debug mode. I check the php-asmanager.php file but could not find what it does control.

Fixes: #106